### PR TITLE
Adds conda_dependencies to GitSource

### DIFF
--- a/texasbbq.py
+++ b/texasbbq.py
@@ -147,6 +147,10 @@ class GitSource(object):
         raise NotImplementedError
 
     @property
+    def conda_dependencies(self):
+        raise NotImplementedError
+
+    @property
     def install_command(self):
         raise NotImplementedError
 
@@ -154,6 +158,8 @@ class GitSource(object):
         if not os.path.exists(self.name):
             execute("git clone -b {} {} {}".format(
                 self.git_ref, self.clone_url, self.name))
+            for dep in self.conda_dependencies:
+                conda_install(env, dep)
             os.chdir(self.name)
             execute("conda run -n {} {}".format(env, self.install_command))
             os.chdir('../')


### PR DESCRIPTION
This PR adds a `conda_dependencies` property to the `GitSource` class for installing source project-related dependencies into the test environment. This is similar to how dependencies are installed for the `GitTarget` class. 

#### Motivating example

When setting up a `GitSource` for Dask and a `GitTarget` for XArray, the `install_command` property for Dask could be either `pip install -e .` to just install Dask, or `pip install -e .[complete]` to install Dask *and* its dependencies from PyPI. However, it would be nice to not mix `pip` installed dependencies from Dask and `conda` installed dependencies from XArray. Moreover, other projects may have difficult to install dependencies so `conda` installing deps would be more than just a preference. 



What do you think about this approach @esc?