### PR TITLE
hotfix for conda run -n bug

### DIFF
--- a/texasbbq.py
+++ b/texasbbq.py
@@ -113,7 +113,7 @@ def conda_update_conda():
     execute("conda update -y -n base -c defaults conda")
     # FIXME: remove this when https://github.com/conda/conda/pull/9665 is
     # merged and released
-    execute("conda install conda=4.8")
+    execute("conda install conda=4.7")
 
 
 def conda_environments():

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -113,7 +113,7 @@ def conda_update_conda():
     execute("conda update -y -n base -c defaults conda")
     # FIXME: remove this when https://github.com/conda/conda/pull/9665 is
     # merged and released
-    execute("conda install conda=4.7")
+    execute("conda install conda=4.8")
 
 
 def conda_environments():

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -111,6 +111,9 @@ def git_checkout(tag):
 
 def conda_update_conda():
     execute("conda update -y -n base -c defaults conda")
+    # FIXME: remove this when https://github.com/conda/conda/pull/9665 is
+    # merged and released
+    execute("conda install conda=4.7")
 
 
 def conda_environments():

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -113,7 +113,7 @@ def conda_update_conda():
     execute("conda update -y -n base -c defaults conda")
     # FIXME: remove this when https://github.com/conda/conda/pull/9665 is
     # merged and released
-    execute("conda install conda=4.7")
+    execute("conda install -y conda=4.7")
 
 
 def conda_environments():


### PR DESCRIPTION
As of conda 0.48.1 `conda run -n` doesn't exit with the code that the
command it ran exited with. This causes all the Numba integration tests
to silently be successful. A PR is in flight to fix this already, but we
hotfix it for now to get the tests up and running again.

Issue:

https://github.com/conda/conda/issues/9599

PR:

https://github.com/conda/conda/pull/9665