### PR TITLE
implement git_latest_tag

### DIFF
--- a/system_test.py
+++ b/system_test.py
@@ -8,7 +8,7 @@ version of umap. If anything fails, it's probably due to a bug in texasbbq.
 """
 
 from texasbbq import (main,
-                      git_ls_remote_tags,
+                      git_latest_tag,
                       CondaSource,
                       GitTarget,
                       )
@@ -38,8 +38,9 @@ class UmapTests(GitTarget):
 
     @property
     def git_ref(self):
-        return([t for t in git_ls_remote_tags(self.clone_url) if not
-                t.startswith("v")][-1])
+        return git_latest_tag(self.clone_url,
+                              vprefix=False,
+                              exclude_filter=lambda x: x.startswith("v"))
 
     @property
     def conda_dependencies(self):

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 import json
 
+from packaging.version import parse
+
 
 MINICONDA_BASE_URL = "https://repo.continuum.io/miniconda/"
 MINCONDA_FILE_TEMPLATE = "Miniconda3-latest-{}.sh"
@@ -108,6 +110,31 @@ def git_ls_remote_tags(url):
     return [os.path.basename(line.split("\t")[1])
             for line in execute("git ls-remote --tags --refs {}".format(url),
             capture=True).decode("utf-8").split("\n") if line]
+
+
+def git_latest_tag(url, vprefix=True, exclude_filter=lambda x: False):
+    """ Get the latest tag from a git repository.
+
+    This uses packaging.version.parse to sort the tags at the given url and
+    returns the largest one.
+
+    Parameters
+    ----------
+    url: str
+        The url of the git reproitory to use
+    vprefix: bool
+        Prefix the return value with the letter 'v'
+    exclude_filter: single argument callable
+        A filter to exclude certain tags from the git repo
+
+    Returns
+    -------
+    str: the latest tag from the git repo
+    """
+
+    latest = str(sorted([parse(t) for t in git_ls_remote_tags(url)
+                         if not exclude_filter(t)])[-1])
+    return "v" + latest if vprefix else latest
 
 
 # untested, because pending removal

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -107,6 +107,24 @@ class TestGit(unittest.TestCase):
             "git ls-remote --tags --refs test_url", capture=True)
 
 
+class TestGitLatestTag(unittest.TestCase):
+
+    @mock.patch("texasbbq.git_ls_remote_tags")
+    def test_git_latest_tag(self, mock_ls_remote_tags):
+        mock_ls_remote_tags.return_value = (
+            ["v.1.0", "0.10.0", "v0.11.0"]
+        )
+        result = texasbbq.git_latest_tag("MOCK_URL", vprefix=False)
+        self.assertEqual("0.11.0", result)
+        result = texasbbq.git_latest_tag("MOCK_URL", vprefix=True)
+        self.assertEqual("v0.11.0", result)
+
+        result = texasbbq.git_latest_tag(
+            "MOCK_URL", vprefix=False,
+            exclude_filter=lambda x: x == "v0.11.0")
+        self.assertEqual("0.10.0", result)
+
+
 class TestConda(unittest.TestCase):
 
     @mock.patch("texasbbq.execute")


### PR DESCRIPTION
This is a utility function that can be used in targets to determine the
latest version of the software from the available git tags. It uses the
`parse` method from `packaging.version` to determine the order of the
versions. If the tags are somewhat sane this does a good job. The
keyword argument `vprefix` can be used to prefix the resulting version
with a `v`, which is a common versioning scenario. The keyword argument
`exclude_filter` can be used to exclude tags, or sets  of tags that
should not be considered, for example non-parsable tags like `docs` or
`website`. Supply a callable that takes a single argument and  returns
`True` if that argument should be exluded.