### PR TITLE
pin to python 3.7 for execution

### DIFF
--- a/texasbbq.py
+++ b/texasbbq.py
@@ -148,7 +148,7 @@ def conda_update_conda():
     execute("conda update -y -n base -c defaults conda")
     # FIXME: remove this when https://github.com/conda/conda/pull/9665 is
     # merged and released
-    execute("conda install -y conda=4.7")
+    execute("conda install -y conda=4.7 python=3.7")
 
 
 def conda_environments():

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -132,7 +132,7 @@ class TestConda(unittest.TestCase):
         texasbbq.conda_update_conda()
         mock_execute.assert_has_calls(
             [mock.call("conda update -y -n base -c defaults conda"),
-             mock.call("conda install -y conda=4.7")])
+             mock.call("conda install -y conda=4.7 python=3.7")])
 
     @mock.patch("texasbbq.execute")
     def test_conda_environments(self, mock_execute):


### PR DESCRIPTION
For `conda run` to work, the following patch is needed:

https://github.com/conda/conda/pull/9665

This means, the `texasbbq` package is stuck on conda=4.7. The latest
miniconda, offers Python 3.8 by default, but conda 4.7 isn't compatible
with Python 3.8 resulting in the following error during installation:

```
UnsatisfiableError: The following specifications were found
to be incompatible with the existing python installation in your environment:

Specifications:

  - conda=4.7 -> python[version='>=2.7,<2.8.0a0|>=3.6,<3.7.0a0|>=3.7,<3.8.0a0']

Your python: python=3.8
```

As a temporary workaround while we wait for a conda version that
includes the above patch, we pin Python  to 3.7.