### PR TITLE
print package details at end

### DIFF
--- a/texasbbq.py
+++ b/texasbbq.py
@@ -51,9 +51,9 @@ def execute(command, capture=False):
     """Execute a command and potentially capture and return its output."""
     echo("running: '{}'".format(command))
     if capture:
-        return subprocess.check_output(shlex.split(command))
+        return subprocess.check_output(command, shell=True)
     else:
-        subprocess.check_call(shlex.split(command))
+        subprocess.check_call(command, shell=True)
 
 
 UNAME = execute("uname", capture=True).strip().decode("utf-8")
@@ -437,6 +437,11 @@ def print_environment_details(target):
     execute("conda list -n {}".format(target.name))
 
 
+def print_package_details(source_name, target_name):
+    execute("conda list -n {} | grep -e {} -e {}"
+            .format(target_name, source_name, target_name))
+
+
 def find_all_targets(module):
     """Inspect a module and discover all subclasses of GitTarget."""
     return [
@@ -508,6 +513,7 @@ def run(source, stages, available_targets, targets):
                     target.test()
                 except subprocess.CalledProcessError:
                     failed.append(target.name)
+        print_package_details(source.name, target.name)
     if STAGE_TESTS in stages:
         if failed:
             echo("The following tests failed: '{}'".format(failed))

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -438,8 +438,8 @@ def print_environment_details(target):
 
 
 def print_package_details(source_name, target_name):
-    lines= execute("conda list -n {}".format(target_name),
-                   capture=True).decode("utf-8").split("\n")
+    lines = execute("conda list -n {}".format(target_name),
+                    capture=True).decode("utf-8").split("\n")
     for l in lines[:3]:
         print(l)
     for l in lines[3:]:

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -438,8 +438,13 @@ def print_environment_details(target):
 
 
 def print_package_details(source_name, target_name):
-    execute("conda list -n {} '(.*{}.*)|(.*{}.*)'"
-            .format(target_name, source_name, target_name))
+    lines= execute("conda list -n {}".format(target_name),
+                   capture=True).decode("utf-8").split("\n")
+    for l in lines[:3]:
+        print(l)
+    for l in lines[3:]:
+        if source_name in l or target_name in l:
+            print(l)
 
 
 def find_all_targets(module):

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -51,9 +51,9 @@ def execute(command, capture=False):
     """Execute a command and potentially capture and return its output."""
     echo("running: '{}'".format(command))
     if capture:
-        return subprocess.check_output(command, shell=True)
+        return subprocess.check_output(shlex.split(command))
     else:
-        subprocess.check_call(command, shell=True)
+        subprocess.check_call(shlex.split(command))
 
 
 UNAME = execute("uname", capture=True).strip().decode("utf-8")
@@ -438,7 +438,7 @@ def print_environment_details(target):
 
 
 def print_package_details(source_name, target_name):
-    execute("conda list -n {} | grep -e {} -e {}"
+    execute("conda list -n {} '(.*{}.*)|(.*{}.*)'"
             .format(target_name, source_name, target_name))
 
 


### PR DESCRIPTION
One of the most common questions when running integration tests is:
"what were the final package versions that you ran with?". Since this
is so common, we now print the final versions of the relevant packages
at the end of the test-run.