### PR TITLE
execute conda run with --no-capture-output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ and has only a single third-party python dependency: `packaging`. Hence it will
 probably run on a large variety of different CI systems and platforms. It
 provides a pure Python interface to ``conda`` without using a shell language.
 A self-contained miniconda distribution containing at least ``conda`` 4.9 will
-be dowwnloaded to ensure a clean build.
+be downloaded to ensure a clean build.
 
 It has multiple *stages*, which are actions to perform and multiple *targets*,
 which are projects to be tested.

--- a/README.rst
+++ b/README.rst
@@ -51,11 +51,8 @@ drive integration testing. This script will run on at least Python 2.7 and 3.7
 and has only a single third-party python dependency: `packaging`. Hence it will
 probably run on a large variety of different CI systems and platforms. It
 provides a pure Python interface to ``conda`` without using a shell language.
-It will need at least `conda` 4.9 to operate.
-
-The script will download and bootstrap a self-contained miniconda distribution
-to ensure a clean build.  You can also run it locally in case you need to debug
-a build or want to add a new project to test.
+A self-contained miniconda distribution containing at least ``conda`` 4.9 will
+be dowwnloaded to ensure a clean build.
 
 It has multiple *stages*, which are actions to perform and multiple *targets*,
 which are projects to be tested.

--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,11 @@ module ``texasbbq`` will then provides a command-line interface for running the
 tests (see blow).
 
 The main entry point is a single script, ``texasbbq.py``, which is used to
-drive integration testing. This script will run on at least Python 2.7 and
-3.7 and has zero third-party dependencies. Hence it will probably run on a
-large variety of different CI systems and platforms. It provides a pure Python
-interface to ``miniconda`` without using a shell language.
+drive integration testing. This script will run on at least Python 2.7 and 3.7
+and has only a single third-party python dependency: `packaging`. Hence it will
+probably run on a large variety of different CI systems and platforms. It
+provides a pure Python interface to ``conda`` without using a shell language.
+It will need at least `conda` 4.9 to operate.
 
 The script will download and bootstrap a self-contained miniconda distribution
 to ensure a clean build.  You can also run it locally in case you need to debug
@@ -58,6 +59,15 @@ a build or want to add a new project to test.
 
 It has multiple *stages*, which are actions to perform and multiple *targets*,
 which are projects to be tested.
+
+Dependencies
+------------
+
+* Executable
+  * `git`
+  * `conda` (4.9) (Will be downloaded during operation, see above.)
+* Python packages
+  * `packaging`
 
 Sources
 -------

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -265,7 +265,7 @@ class GitSource(object):
             for dep in self.conda_dependencies:
                 conda_install(env, dep)
             os.chdir(self.name)
-            execute("conda run -n {} {}".format(env, self.install_command))
+            execute("conda run --no-capture-output -n {} {}".format(env, self.install_command))
             os.chdir('../')
 
 
@@ -397,13 +397,13 @@ class GitTarget(object):
         if not os.path.exists(self.name):
             self.clone()
         os.chdir(self.name)
-        execute("conda run -n {} {}".format(self.name, self.install_command))
+        execute("conda run --no-capture-output -n {} {}".format(self.name, self.install_command))
         os.chdir('../')
 
     def test(self):
         """Run targets test command inside conda environment."""
         os.chdir(self.name)
-        execute("conda run -n {} {}".format(self.name, self.test_command))
+        execute("conda run --no-capture-output -n {} {}".format(self.name, self.test_command))
         os.chdir('../')
 
 

--- a/texasbbq.py
+++ b/texasbbq.py
@@ -473,7 +473,7 @@ class CondaTarget(object):
 
     def test(self):
         """Run targets test command inside conda environment."""
-        execute("conda run -n {} {}".format(self.name, self.test_command))
+        execute("conda run --no-capture-output -n {} {}".format(self.name, self.test_command))
 
 
 def bootstrap_miniconda():


### PR DESCRIPTION
The default behaviour of `conda run` is to buffer the output and then
display the entire running output after the command has completed. For
long running compile or testing processes this is suboptimal from a
usability perspective since the progress can not be monitored in
real-time. Adding the flag `--no-capture-output` means that `conda run`
will not buffer the output but stream it directly to the terminal which
improves usability.